### PR TITLE
Really do not create home when server.user create_home is False

### DIFF
--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -1037,6 +1037,8 @@ def user(
 
         if create_home:
             args.append("-m")
+        else:
+            args.append("-M")
 
         # Users are often added by other operations (package installs), so check
         # for the user at runtime before adding.


### PR DESCRIPTION
Home folders may be created by default following a setting in /etc/login.defs. 
See https://linux.die.net/man/8/useradd.

Make sure it is not created when create_home is False.